### PR TITLE
Binary linking.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "supertest": "3.1.0",
     "ws": "5.1.1"
   },
+  "bin": {
+    "ft-server": "bin/server.js"
+  }
   "scripts": {
     "test": "mocha --check-leaks **/*.test.js",
     "start": "./bin/server.js",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "bin": {
     "ft-server": "bin/server.js"
-  }
+  },
   "scripts": {
     "test": "mocha --check-leaks **/*.test.js",
     "start": "./bin/server.js",


### PR DESCRIPTION
Some binaries are not linked in package.json, causing npx to fail on meh.